### PR TITLE
feat: Allow dynamic label management for LokiClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ migrate_working_dir/
 .flutter-plugins-dependencies
 build/
 example/lib/constant.dart
+example/lib/runner.dart

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.3
+Released on 2025-05-23
+* Exposed functions to update labels
+
 ### 1.0.2
 Released on 2025-05-23
 * Added Support for dart 3.2

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -59,4 +59,20 @@ void main() {
       'sessionId': '9999990-09099439-2983727328',
     });
   }
+
+  logger.lokiClient?.addLabels({
+    'user': 'John Doe',
+    'device': 'iPhone',
+    'os': 'iOS',
+    'os_version': '14.5',
+  });
+  logger.f('Fatal error occurred, this should carry new labels');
+  logger.i('Just for you info here');
+  logger.lokiClient?.removeLabel('user');
+  logger.i('Just for you info here');
+  logger.lokiClient?.resetLabels();
+  logger.i('Now labels are reset');
+
+  // Dispose the logger to free up resources
+  logger.dispose();
 }

--- a/lib/src/loki_client.dart
+++ b/lib/src/loki_client.dart
@@ -11,6 +11,9 @@ class LokiClient {
   /// Queue of log entries waiting to be sent
   final List<Map<String, dynamic>> _queue = [];
 
+  /// Map of labels to be added to each log
+  final Map<String, String> _labels = {};
+
   /// Timer for batch sending
   Timer? _batchTimer;
 
@@ -21,6 +24,7 @@ class LokiClient {
         (_) => _sendBatch(),
       );
     }
+    _labels.addAll(config.labels ?? {});
   }
 
   /// Logs a message to Loki
@@ -82,8 +86,8 @@ class LokiClient {
     }
 
     // Add global labels
-    if (config.labels != null) {
-      allLabels.addAll(config.labels!);
+    if (_labels.isNotEmpty) {
+      allLabels.addAll(_labels);
     }
 
     // Add custom labels for this log
@@ -186,8 +190,25 @@ class LokiClient {
     }
   }
 
+  /// Adds labels to the logger
+  void addLabels(Map<String, String> labels) {
+    _labels.addAll(labels);
+  }
+
+  /// Removes all labels from the logger
+  void resetLabels() {
+    _labels.clear();
+  }
+
+  /// Removes a specific label from the logger
+  void removeLabel(String key) {
+    _labels.remove(key);
+  }
+
   /// Disposes resources used by this logger
   void dispose() {
+    _queue.clear();
+    _labels.clear();
     _batchTimer?.cancel();
     _sendBatch(); // Send any remaining logs
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,10 @@
 name: loki_logger
 description: "Dart utility library for publishing logs to a Loki Server"
-version: 1.0.2
+version: 1.0.3
 homepage: "https://github.com/Dammyololade/loki_logger"
 topics:
   - logging
+  - remote-logging
   - loki
 
 environment:


### PR DESCRIPTION
This commit introduces the ability to dynamically add, remove, and reset labels for the `LokiClient`.

Key changes:
- `LokiClient` now maintains its own internal `_labels` map, initialized with labels from `LokiConfig`.
- Added `addLabels(Map<String, String> labels)` to add new labels or update existing ones.
- Added `removeLabel(String key)` to remove a specific label.
- Added `resetLabels()` to clear all currently set labels.
- The `dispose()` method in `LokiClient` now also clears the internal `_labels` map and the log `_queue`.
- Updated the example to demonstrate the usage of these new label management functions.

This enhancement provides more flexibility in managing log labels at runtime.

The package version has been updated to 1.0.3, and "remote-logging" has been added as a topic in `pubspec.yaml`. The `.gitignore` file has been updated to ignore `example/lib/runner.dart`. The `CHANGELOG.md` has been updated with the details of this release.