### PR TITLE
Support Bearer authentication for Loki via Grafana proxy

### DIFF
--- a/lib/src/loki_client.dart
+++ b/lib/src/loki_client.dart
@@ -167,6 +167,10 @@ class LokiClient {
       // Prepare request
       final headers = <String, String>{'Content-Type': 'application/json'};
 
+      // Authentication headers
+      if (config.bearerToken != null) {
+        headers['Authorization'] = 'Bearer ${config.bearerToken}';
+      }
       if (config.basicAuth != null) {
         final encodedAuth = base64Encode(utf8.encode(config.basicAuth!));
         headers['Authorization'] = 'Basic $encodedAuth';

--- a/lib/src/loki_config.dart
+++ b/lib/src/loki_config.dart
@@ -21,6 +21,9 @@ class LokiConfig {
   /// Timeout for requests to Grafana Loki in milliseconds
   final int? timeout;
 
+  /// Bearer authentication token to access Loki through Grafana’s data source proxy over HTTP
+  final String? bearerToken;
+
   /// Basic authentication credentials to access Loki over HTTP
   final String? basicAuth;
 
@@ -33,5 +36,9 @@ class LokiConfig {
     this.labels,
     this.timeout,
     this.basicAuth,
-  });
+    this.bearerToken,
+  }) : assert(
+          bearerToken == null || basicAuth == null,
+          'Cannot use both bearer token and basic auth at the same time',
+        );
 }


### PR DESCRIPTION
Previously, the loki_logger client supported Basic Authentication only when connecting directly to the Loki host.
In my use case, Loki is accessed through Grafana’s data source proxy, which requires authentication via an API token.

With this change, the logger can now also use Bearer token authentication.
In this setup, the host URL is structured as: `https://<your-grafana-host>/api/datasources/proxy/uid/<loki-uid>`

This makes the integration more flexible and compatible with different deployment setups.