### PR TITLE
feat: Add support for Bearer Authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 1.1.0
+Added support for Bearer Authentication thanks to [Julia Werner](https://github.com/juliaWernerLime)
 ### 1.0.4
 Released on 2025-06-09
 * Fixed [issue-6](https://github.com/Dammyololade/loki_logger/issues/6)
@@ -9,7 +11,7 @@ Released on 2025-05-23
 Released on 2025-05-23
 * Added Support for dart 3.2
 * Fixed issues with batching logs
-* Removed flutter dependency thanks to (Nicola Verbeeck)[https://github.com/NicolaVerbeeck]
+* Removed flutter dependency thanks to [Nicola Verbeeck](https://github.com/NicolaVerbeeck)
 
 ## 1.0.1
 Released on 2025-05-14

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: loki_logger
 description: "Dart utility library for publishing logs to a Loki Server"
-version: 1.0.4
+version: 1.1.0
 homepage: "https://github.com/Dammyololade/loki_logger"
 topics:
   - logging


### PR DESCRIPTION
This commit introduces support for Bearer Authentication, allowing the client to authenticate with the Loki server using a bearer token.

The package version has been updated to 1.1.0 in `pubspec.yaml`. The `CHANGELOG.md` has been updated to reflect this new feature.